### PR TITLE
Update branch of dependency repository `msgraph-training-ios-objectivec`

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -88,7 +88,7 @@
     {
       "path_to_root": "tutorials/ios-objectivec",
       "url": "https://github.com/microsoftgraph/msgraph-training-ios-objectivec",
-      "branch": "tutorial",
+      "branch": "master",
       "branch_mapping": {
         "master": "master",
         "live": "live"


### PR DESCRIPTION
This fix is to unblock the docfx v3 migration. since the branch `tutorial` doesn't exist in the dependency repository `msgraph-training-ios-objectivec`, the build will fail if the current build branch is not master or live.
Please help to review and merge this PR.