### PR TITLE
set `include_in_build` for dependent repositories

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -38,7 +38,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/angular",
@@ -47,7 +48,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/aspnet",
@@ -56,7 +58,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/change-notifications",
@@ -65,7 +68,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/dotnet-core",
@@ -74,7 +78,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/flow",
@@ -83,7 +88,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/ios-objectivec",
@@ -92,7 +98,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/ios-swift",
@@ -101,7 +108,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/java",
@@ -110,7 +118,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/node",
@@ -119,7 +128,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/php",
@@ -128,7 +138,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/python",
@@ -137,7 +148,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/react",
@@ -146,7 +158,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/react-native",
@@ -155,7 +168,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/ruby",
@@ -164,7 +178,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/uwp",
@@ -173,7 +188,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     },
     {
       "path_to_root": "tutorials/xamarin",
@@ -182,7 +198,8 @@
       "branch_mapping": {
         "master": "master",
         "live": "live"
-      }
+      },
+      "include_in_build": true
     }
   ],
   "branch_target_mapping": {},


### PR DESCRIPTION
This pull request is related to docfx v3 migration and won't bring any impact to your current published content page.

This is a change of the current build system, you have to add the flag include_in_build if you want to build the files the dependent repository as a content file.