### PR TITLE
set redirect_document_id to false

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -3,42 +3,42 @@
     {
       "source_path": "training/aspnet-tutorial.md",
       "redirect_url": "/graph/tutorials/aspnet",
-      "redirect_document_id": true
+      "redirect_document_id": false
     },
     {
       "source_path": "training/flow-tutorial.md",
       "redirect_url": "/graph/tutorials/flow",
-      "redirect_document_id": true
+      "redirect_document_id": false
     },
     {
       "source_path": "training/node-tutorial.md",
       "redirect_url": "/graph/tutorials/node",
-      "redirect_document_id": true
+      "redirect_document_id": false
     },
     {
       "source_path": "training/php-tutorial.md",
       "redirect_url": "/graph/tutorials/php",
-      "redirect_document_id": true
+      "redirect_document_id": false
     },
     {
       "source_path": "training/python-tutorial.md",
       "redirect_url": "/graph/tutorials/python",
-      "redirect_document_id": true
+      "redirect_document_id": false
     },
     {
       "source_path": "training/react-tutorial.md",
       "redirect_url": "/graph/tutorials/react",
-      "redirect_document_id": true
+      "redirect_document_id": false
     },
     {
       "source_path": "training/ruby-tutorial.md",
       "redirect_url": "/graph/tutorials/ruby",
-      "redirect_document_id": true
+      "redirect_document_id": false
     },
     {
       "source_path": "training/uwp-tutorial.md",
       "redirect_url": "/graph/tutorials/uwp",
-      "redirect_document_id": true
+      "redirect_document_id": false
     }
   ]
 }


### PR DESCRIPTION
There is a known issue in the current build system: if the redirect target is a yaml file, the redirection flag `redirect_document_id` will not work, so to unblock the migration of docfx v3, please turn off this flag, this won't bring any impact to your current published page, after migrating to docfx v3, you can turn on this flag for those redirection rules, that will become effective.