### PR TITLE
Added global ms.prod and ms.technology metadata

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -62,7 +62,9 @@
       "breadcrumb_path": "/graph/breadcrumb/toc.json",
       "extendBreadcrumb": true,
       "feedback_system": "None",
-      "uhfHeaderId": "MSDocsHeader-MSGraph"
+      "uhfHeaderId": "MSDocsHeader-MSGraph",
+      "ms.prod": "non-product-specific",
+      "ms.technology": "ms-graph"
     },
     "fileMetadata": {
       "featureFlags": {


### PR DESCRIPTION
Setting `ms.prod` and `ms.technology` globally in lieu of #87 