### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft Graph Training
 
-This repository holds the YAML files used to generate the [Microsoft Graph Tutorials](https://docs.microsoft.com/graph/tutorials/).
+This repository holds the YAML files used to generate the [Microsoft Graph Tutorials](https://learn.microsoft.com/graph/tutorials/).
 
 ## Microsoft Open Source Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
