### PR TITLE
Fix typos in PHP app-only tutorial

### DIFF
--- a/tutorials/includes/php/app-only/04-add-app-only-auth.md
+++ b/tutorials/includes/php/app-only/04-add-app-only-auth.md
@@ -46,7 +46,7 @@ Next, add code to get an access token from the `GraphHelper`.
 
     :::code language="php" source="../src/app-auth/graphapponlytutorial/main.php" id="DisplayAccessTokenSnippet":::
 
-1. Build and run the app. Enter `1` when prompted for an option. The application displays a URL and device code.
+1. Build and run the app. Enter `1` when prompted for an option. The application displays the access token it has fetched using the authentication information configured previously in the environment variables.
 
     ```bash
     $ php main.php

--- a/tutorials/includes/php/app-only/05-get-all-users.md
+++ b/tutorials/includes/php/app-only/05-get-all-users.md
@@ -14,7 +14,7 @@ In this section you will add the ability to list all users in your Azure Active 
 
     :::code language="php" source="../src/app-auth/graphapponlytutorial/main.php" id="ListUsersSnippet":::
 
-1. Run the app, sign in, and choose option 4 to list users.
+1. Run the app, sign in, and choose option 2 to list users.
 
     ```Shell
     Please choose one of the following options:


### PR DESCRIPTION
Fixed a copy/paste error and a typo in the app-only tutorial for PHP